### PR TITLE
Add GitHub Skills activity (resolves #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Tuesdays and Thursdays, 4:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing GitHub Skills activity that was announced by the principal in the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities list in `src/app.py`
- Activity includes details about practical coding and collaboration skills
- Part of the GitHub Certifications program for college applications
- Schedule: Tuesdays and Thursdays, 4:30 PM - 5:30 PM
- Capacity: 25 participants

## Resolves
- Fixes #6: Missing Activity: GitHub Skills

## Testing
The activity should now appear in the student activity list and be available for registration.